### PR TITLE
Add a way to get/set meta properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-SOCIALENGINE_STRD='./vendor/socialengine/sniffer-rules/src/Socialengine/SnifferRules/Standard/SocialEngine'
+SOCIALENGINE_STRD="`pwd`/vendor/socialengine/sniffer-rules/src/Socialengine/SnifferRules/Standard/"
+PHPCS=php ./vendor/bin/phpcs
+INSTALLED=$(shell ${PHPCS} -i)
 
 test:
 	php ./vendor/bin/phpunit
@@ -6,8 +8,13 @@ test:
 test-cover:
 	php ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
-sniff:
-	php ./vendor/bin/phpcs --colors --standard=${SOCIALENGINE_STRD} --runtime-set allowSnakeCaseMethodName '[{"classSuffix":"Test","methodPrefix":["test"]}]' src tests
+sniff: check-standard
+	${PHPCS} --colors --standard=SocialEngine --runtime-set allowSnakeCaseMethodName '[{"classSuffix":"Test","methodPrefix":["test"]}]' src tests
 
-sniff-fix:
-	php ./vendor/bin/phpcbf --colors --standard=${SOCIALENGINE_STRD} --runtime-set allowSnakeCaseMethodName '[{"classSuffix":"Test","methodPrefix":["test"]}]' src tests
+sniff-fix: check-standard
+	php ./vendor/bin/phpcbf --colors --standard=SocialEngine --runtime-set allowSnakeCaseMethodName '[{"classSuffix":"Test","methodPrefix":["test"]}]' src tests
+
+check-standard:
+ifeq (,$(findstring SocialEngine, $(INSTALLED)))
+	php ./vendor/bin/phpcs --config-set installed_paths ${SOCIALENGINE_STRD}
+endif

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SOCIALENGINE_STRD='./vendor/socialengine/sniffer-rules/src/Socialengine/SnifferRules/Standard/SocialEngine'
+
 test:
 	php ./vendor/bin/phpunit
 
@@ -5,8 +7,7 @@ test-cover:
 	php ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
 sniff:
-	php ./vendor/bin/phpcs --colors --standard=SocialEngine --runtime-set allowSnakeCaseMethodName '[{"classSuffix":"Test","methodPrefix":["test"]}]' src tests
+	php ./vendor/bin/phpcs --colors --standard=${SOCIALENGINE_STRD} --runtime-set allowSnakeCaseMethodName '[{"classSuffix":"Test","methodPrefix":["test"]}]' src tests
 
 sniff-fix:
-	php ./vendor/bin/phpcbf --colors --standard='./vendor/socialengine/sniffer-rules/src/Socialengine/SnifferRules/Standard/SocialEngine' --runtime-set allowSnakeCaseMethodName '[{"classSuffix":"Test","methodPrefix":["test"]}]' src tests
-
+	php ./vendor/bin/phpcbf --colors --standard=${SOCIALENGINE_STRD} --runtime-set allowSnakeCaseMethodName '[{"classSuffix":"Test","methodPrefix":["test"]}]' src tests

--- a/README.md
+++ b/README.md
@@ -133,6 +133,67 @@ array(0) {
 */
 ```
 
+### Meta Attributes
+
+You can set and get "meta" attributes - ones that do not have attributes directly attached to them.
+
+This is good if you have an entity that stores a `category_id` but does not store the category name
+
+```php
+<?php
+
+require('vendor/autoload.php');
+
+class MyEntity extends \SocialEngine\Unum\Entity
+{
+  protected $category_id;
+  protected $first_name;
+  protected $last_name;
+
+  protected function getCategoryName()
+  {
+    $categoryNamesMap = [
+      1 => 'Awesome'
+    ];
+
+    return $categoryNamesMap[$this->getProp('category_id')];
+  }
+
+  /**
+   * You can also set meta properties
+   */
+  protected function setName($name)
+  {
+    list($firstName, $lastName) = explode(' ', $name, 2);
+
+    $this->fromArray([
+      'first_name' => $firstName,
+      'last_name' => $lastName
+    ]);
+  }
+}
+
+$entity = new MyEntity(['category_id' => 1]);
+var_dump($entity->categoryName);
+/*
+string(7) "Awesome"
+*/
+
+$entity['name'] = 'Duke Orcino';
+var_dump($entity->toArray(true));
+/*
+array(2) {
+  'first_name' =>
+  string(4) "Duke"
+  'last_name' =>
+  string(6) "Orcino"
+}
+*/
+```
+
+The entity above will let you access Meta attributes via the normal syntax. Use build in `setProp` and `getProp` so 
+that you can leverage some of the validation and attribute checking code **Unum** offers you.
+
 ## Code Style
 
 Please follow the following guides and code standards:

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -70,6 +70,22 @@ class EntityTest extends TestCase
         $entity->fake = 1;
     }
 
+    public function test_meta_property_get()
+    {
+        $entity = new TestEntity();
+        $this->assertEquals($entity::META_PROPERTY, $entity->customMethodProp);
+    }
+
+    public function test_meta_property_set()
+    {
+        $entity = new TestEntity();
+        $entity->uppercaseTestProp = 'lowercase_test';
+        $this->assertEquals(strtoupper('lowercase_test'), $entity->testProp);
+
+        $entity2 = new TestEntity(['uppercaseTestProp' => 'lowercase_test']);
+        $this->assertEquals(strtoupper('lowercase_test'), $entity->testProp);
+    }
+
     public function test_isset()
     {
         $entity = new TestEntity(['testProp' => 'test1']);

--- a/tests/Fixtures/TestEntity.php
+++ b/tests/Fixtures/TestEntity.php
@@ -17,6 +17,13 @@ class TestEntity extends Entity
     protected $test_prop;
     // @codingStandardsIgnoreEnd
 
+    /**
+     * For accessing from tests
+     *
+     * @var string
+     */
+    const META_PROPERTY = 'This is a meta property';
+
     protected function getGetMethodProp()
     {
         return $this->getMethodProp . ' From Get';
@@ -25,5 +32,15 @@ class TestEntity extends Entity
     protected function setSetMethodProp($value)
     {
         $this->setMethodProp = $value . ' From Set';
+    }
+
+    protected function getCustomMethodProp()
+    {
+        return self::META_PROPERTY;
+    }
+
+    public function setUppercaseTestProp($value)
+    {
+        $this->setProp('testProp', strtoupper($value));
     }
 }


### PR DESCRIPTION
### What is the problem / feature ?

Meta properties are sometimes great to use in cases where you do not have defined property (as its not in the db) but you still want to set or get a property from an entity.

We have a use case: if you have `category_id`stored in the db, it would be great to map that category id to an actual category name.
### How did it get fixed / implemented ?
- switched around the order of how properties are checked
- added documentation
### How can someone test / see it ?

Following test file works as advertised:

``` php
<?php

require('vendor/autoload.php');

class MyEntity extends \SocialEngine\Unum\Entity
{
  protected $category_id;
  protected $first_name;
  protected $last_name;

  protected function getCategoryName()
  {
    $categoryNamesMap = [
      1 => 'Awesome'
    ];

    return $categoryNamesMap[$this->getProp('category_id')];
  }

  /**
   * You can also set meta properties
   */
  protected function setName($name)
  {
    list($firstName, $lastName) = explode(' ', $name, 2);

    $this->fromArray([
      'first_name' => $firstName,
      'last_name' => $lastName
    ]);
  }
}

$entity = new MyEntity(['category_id' => 1]);
var_dump($entity->categoryName);
/*
string(7) "Awesome"
*/

$entity['name'] = 'Duke Orcino';
var_dump($entity->toArray(true));
/*
array(2) {
  'first_name' =>
  string(4) "Duke"
  'last_name' =>
  string(6) "Orcino"
}
*/
```

Note accepting this PR will be a BC break and require a new major version. Sorry about that.
