### PR TITLE
Added trait for property assertions 

### DIFF
--- a/src/Traits/PropertyAsserts.php
+++ b/src/Traits/PropertyAsserts.php
@@ -24,10 +24,10 @@ trait PropertyAsserts
      * Asserts that properties of Entity are loaded.
      *
      * @param  Entity   $entity
-     * @param  string   $properties
+     * @param  array    $properties
      * @param  string   $message
      */
-    public function assertPropertiesLoaded(Entity $entity, $properties, $message = '')
+    public function assertPropertiesLoaded(Entity $entity, array $properties, $message = '')
     {
         array_walk($properties, function ($property) use ($entity, $message) {
             $this->assertPropertyLoaded($entity, $property, $message);
@@ -59,7 +59,7 @@ trait PropertyAsserts
      * @param  array    $properties
      * @param  string   $message
      */
-    public function assertProperties(Entity $entity, $properties = [], $message = '')
+    public function assertProperties(Entity $entity, array $properties, $message = '')
     {
         array_walk($properties, function ($value, $property) use ($entity, $message) {
             $this->assertProperty($entity, $property, $value, $message);

--- a/src/Traits/PropertyAsserts.php
+++ b/src/Traits/PropertyAsserts.php
@@ -1,0 +1,87 @@
+<?php namespace SocialEngine\Unum\Traits;
+
+use SocialEngine\Unum\Contracts\Entity;
+
+trait PropertyAsserts
+{
+    /**
+     * Asserts that a property of Entity is loaded.
+     *
+     * @param  Entity   $entity
+     * @param  string   $property
+     * @param  string   $message
+     */
+    public function assertPropertyLoaded(Entity $entity, $property, $message = '')
+    {
+        if (empty($message)) {
+            $message = 'Failed asserting property loaded: %1$s of %2$s.';
+        }
+        $message = sprintf($message, $property, get_class($entity));
+        $this->assertTrue(isset($entity->{$property}), $message);
+    }
+
+    /**
+     * Asserts that properties of Entity are loaded.
+     *
+     * @param  Entity   $entity
+     * @param  string   $properties
+     * @param  string   $message
+     */
+    public function assertPropertiesLoaded(Entity $entity, $properties, $message = '')
+    {
+        array_walk($properties, function ($property) use ($entity, $message) {
+            $this->assertPropertyLoaded($entity, $property, $message);
+        });
+    }
+
+    /**
+     * Asserts that a property of Entity has the same value.
+     *
+     * @param  Entity   $entity
+     * @param  string   $property
+     * @param  mixed    $value
+     * @param  string   $message
+     */
+    public function assertProperty(Entity $entity, $property, $value = null, $message = '')
+    {
+        $this->assertPropertyLoaded($entity, $property);
+        if (empty($message)) {
+            $message = 'Failed asserting the value %1$s of %2$s.';
+        }
+        $message = sprintf($message, $value, $property);
+        $this->assertSame($value, $entity->{$property}, $message);
+    }
+
+    /**
+     * Asserts that properties of Entity have the same value.
+     *
+     * @param  Entity   $entity
+     * @param  array    $properties
+     * @param  string   $message
+     */
+    public function assertProperties(Entity $entity, $properties = [], $message = '')
+    {
+        array_walk($properties, function ($value, $property) use ($entity, $message) {
+            $this->assertProperty($entity, $property, $value, $message);
+        });
+    }
+
+    /**
+     * Asserts that a condition is true.
+     *
+     * @param  boolean  $condition
+     * @param  string   $message
+     */
+    abstract public function assertTrue($condition, $message = '');
+
+    /**
+     * Asserts that two variables have the same type and value.
+     * Used on objects, it asserts that two variables reference
+     * the same object.
+     *
+     * @param mixed  $expected
+     * @param mixed  $actual
+     * @param string $message
+     */
+    abstract public function assertSame($expected, $actual, $message = '');
+}


### PR DESCRIPTION
### What is the problem / feature ?

We need to assert the properties of entities in phpunit tests. In this PR I've added a trait for asserting the properties of entities.
### How did it get fixed / implemented ?
- Added `SocialEngine\Unum\Traits\PropertyAsserts` trait.
### How can someone use it ?
- For assertingproperties of Entity have the same value: 

```
$properties = [
    'guid' => 'test-guid',
    'email' => 'jesh@mail.com',
];  

$this->assertProperties($entity, $properties);
```
- For asserting properties of Entity are loaded:

```
$properties = [
    'guid' ,
    'email' ,
]; 

$this->assertPropertiesLoaded($entity, $properties);
```
- For asserting a property of Entity has the same value: 

```
$this->assertProperty($entity, 'guid', 'optional')
```
